### PR TITLE
Create WifiPassKey.py

### DIFF
--- a/WifiPassKey.py
+++ b/WifiPassKey.py
@@ -1,0 +1,38 @@
+import subprocess
+
+# Open the command prompt and run the command "netsh wlan show profiles"
+process = subprocess.Popen(["netsh", "wlan", "show", "profiles"], stdout=subprocess.PIPE)
+output, error = process.communicate()
+
+# Print the output of the command
+output = output.decode()
+lines = output.split("\n")
+profiles = []
+for line in lines:
+    if "All User Profile" in line:
+        profiles.append(line.split(":")[1].strip())
+
+# Print the list of WiFi profiles
+print("List of WiFi profiles:")
+for i, profile in enumerate(profiles):
+    print("{}. {}".format(i + 1, profile))
+
+# Ask the user to choose a WiFi profile
+selected_profile = None
+while selected_profile is None:
+    try:
+        choice = int(input("Choose a WiFi profile (enter the number): "))
+        if 1 <= choice <= len(profiles):
+            selected_profile = profiles[choice - 1]
+        else:
+            print("Invalid choice. Please choose a number between 1 and {}.".format(len(profiles)))
+    except ValueError:
+        print("Invalid input. Please enter a valid number.")
+
+# Display the security key for the selected WiFi profile
+command = 'netsh wlan show profile "{}" key=clear | findstr Key'.format(selected_profile)
+process = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
+output, error = process.communicate()
+
+# Print the output of the command
+print(output.decode())


### PR DESCRIPTION
Pull Request Description

This pull request introduces a new feature that allows users to view and retrieve the security key of a selected WiFi profile on Windows. The feature is implemented using Python's subprocess module and the netsh command-line tool.

What the code offers?

- Code to execute the netsh wlan show profiles command and extract a list of available WiFi profiles.
- Prompted the user to select a WiFi profile from the list.
- Executed the netsh wlan show profile "<selected_profile>" key=clear | findstr Key command to obtain the security key for the selected WiFi profile.
- Displayed the security key to the user.
- Reason for the Pull Request

This enhancement offers a convenient way for users to retrieve their WiFi network's security key, which can be useful in various scenarios, such as connecting new devices to the network. It simplifies the process by automating the command execution and presenting the user with a list of profiles to choose from.

How to Test

- Run the script.
- It will display a list of available WiFi profiles.
- Choose a WiFi profile by entering the corresponding number.
- The script will display the security key for the selected WiFi profile.